### PR TITLE
Fix .gitignore for tracked files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,6 @@
 .DS_Store
 node_modules
 .idea
-package-lock.json
 /build
 .vscode/
 .idea/
-vite.config.*s.*


### PR DESCRIPTION
## Summary
- keep `package-lock.json` under version control
- remove it and `vite.config.mjs` patterns from `.gitignore`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6881ecc364b8833093cee0b5cef33668